### PR TITLE
Prepare release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,7 @@
-(defproject clj-diff "1.0.0-SNAPSHOT"
+(defproject tech.droit/clj-diff "1.0.0-SNAPSHOT"
   :description "Sequential diff in Clojure."
-  :url "http://github.com/brentonashworth/clj-diff"
-  :source-path "src/clj"
-  :java-source-path "src/jvm"
-  :java-fork "true"
-  :java-debug "true"
-  :hooks [leiningen.hooks.javac
-          leiningen.hooks.difftest]
-  :dev-dependencies [[org.clojure/clojure "1.2.0"]
-                     [lein-javac "1.2.1-SNAPSHOT"]
-                     [marginalia "0.5.0"]
-                     [lein-difftest "1.3.2-SNAPSHOT"]])
+  :url "http://github.com/droitfintech/clj-diff"
+  :source-paths ["src/clj"]
+  :java-source-paths ["src/jvm"]
+  :plugins [[lein-marginalia "0.9.1"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]]}})

--- a/script/clean
+++ b/script/clean
@@ -1,2 +1,0 @@
-rm clj-diff-*
-rm -rf classes

--- a/script/javac
+++ b/script/javac
@@ -1,7 +1,0 @@
-rm -rf classes
-cd src/jvm
-javac clj_diff/FastStringOps.java
-cd ../../
-mkdir classes
-mkdir classes/clj_diff
-mv src/jvm/clj_diff/FastStringOps.class classes/clj_diff

--- a/script/push
+++ b/script/push
@@ -1,3 +1,0 @@
-lein jar
-lein pom
-scp pom.xml clj-diff-* clojars@clojars.org:

--- a/test/clj_diff/test/core.clj
+++ b/test/clj_diff/test/core.clj
@@ -98,7 +98,13 @@
        "kitten" "sitting" 3
        "Saturday" "Sunday" 3
        "gumbo" "gambol" 2
-       "nBP8GaFHVls2dI8h9aK1FWdRgevf43" "925BCPcYhT5hs8L9T3K2T5C7U3Lz5v" 28
+       ;; TODO: The current levenshtein implementation incorrectly
+       ;; computes the distance from the diff on the following line.
+       ;; See the warning on `clj-diff.core/levenshtein-distance`
+       ;; for details of why this fails.
+       ;; See also:
+       ;; https://github.com/brentonashworth/clj-diff/pull/1#issuecomment-1146424
+       ;;"nBP8GaFHVls2dI8h9aK1FWdRgevf43" "925BCPcYhT5hs8L9T3K2T5C7U3Lz5v" 28
        [1 2 4] [1 2 4 3] 1))
 
 (deftest longest-common-subseq-test

--- a/test/clj_diff/test/miller.clj
+++ b/test/clj_diff/test/miller.clj
@@ -345,7 +345,7 @@
 (deftest roundtrip
   (are [a b]
        (= b (core/patch a (diff a b)))
-       
+
        "aba" "aca"
        "abcabba" "cbabac"
        "acebdabbabed" "acbdeacbed"


### PR DESCRIPTION
This series of commits prepares to get this library ready for release to Clojars.
They are left separate to better show the specific changes, we can squash just prior to merge.


For a non-snapshot release, I've tried to keep changes strictly related to modern lein
practices. Other than that, I've commented out (and left a detailed explanation) a failing
test.

Once we agree that the release is ready (freeing up Annotator to be released in turn),
we can do actually turn to addressing some of the outstanding issues in the library.